### PR TITLE
Fix various exceptions when using a debug Unity build

### DIFF
--- a/BetterSongSearch.csproj
+++ b/BetterSongSearch.csproj
@@ -125,7 +125,7 @@
       <HintPath>$(BeatSaberDir)\Libs\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net">
-      <HintPath>E:\SteamLibrary\steamapps\common\Beat Saber\Libs\protobuf-net.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="SegmentedControl">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\SegmentedControl.dll</HintPath>

--- a/UI/DownloadHistoryView.cs
+++ b/UI/DownloadHistoryView.cs
@@ -84,47 +84,45 @@ namespace BetterSongSearch.UI {
 
 			RefreshTable(true);
 
-			await Task.Run(async () => {
-				void errored(string message) {
-					firstEntry.status = DownloadHistoryEntry.DownloadStatus.Failed;
-					firstEntry.statusDetails = $": {message}";
-					firstEntry.retries = 69;
+			void errored(string message) {
+				firstEntry.status = DownloadHistoryEntry.DownloadStatus.Failed;
+				firstEntry.statusDetails = $": {message}";
+				firstEntry.retries = 69;
+			}
+
+			try {
+				var updateRateLimiter = new Stopwatch();
+				updateRateLimiter.Start();
+
+				await SongDownloader.BeatmapDownload(firstEntry, BSSFlowCoordinator.closeCancelSource.Token, (float progress) => {
+					if(updateRateLimiter.ElapsedMilliseconds < 50)
+						return;
+
+					firstEntry.statusDetails = string.Format("({0:0%}{1})", progress, firstEntry.retries == 0 ? "" : $", retry #{firstEntry.retries} / {RETRY_COUNT}");
+					firstEntry.downloadProgress = progress;
+
+					updateRateLimiter.Restart();
+
+					if(firstEntry.UpdateProgressHandler != null)
+						firstEntry.UpdateProgressHandler();
+				});
+
+				firstEntry.status = DownloadHistoryEntry.DownloadStatus.Downloaded;
+				firstEntry.statusDetails = "";
+			} catch(FileNotFoundException) {
+				errored("File not Found, Uploader probably deleted it");
+			} catch(TaskCanceledException) {
+				errored("Download was cancelled");
+			} catch(Exception ex) {
+				if(!(ex is TaskCanceledException)) {
+					Plugin.Log.Warn("Download failed:");
+					Plugin.Log.Warn(ex);
 				}
 
-				try {
-					var updateRateLimiter = new Stopwatch();
-					updateRateLimiter.Start();
-
-					await SongDownloader.BeatmapDownload(firstEntry, BSSFlowCoordinator.closeCancelSource.Token, (float progress) => {
-						if(updateRateLimiter.ElapsedMilliseconds < 50)
-							return;
-
-						firstEntry.statusDetails = string.Format("({0:0%}{1})", progress, firstEntry.retries == 0 ? "" : $", retry #{firstEntry.retries} / {RETRY_COUNT}");
-						firstEntry.downloadProgress = progress;
-
-						updateRateLimiter.Restart();
-
-						if(firstEntry.UpdateProgressHandler != null)
-							IPA.Utilities.Async.UnityMainThreadTaskScheduler.Factory.StartNew(firstEntry.UpdateProgressHandler);
-					});
-
-					firstEntry.status = DownloadHistoryEntry.DownloadStatus.Downloaded;
-					firstEntry.statusDetails = "";
-				} catch(FileNotFoundException) {
-					errored("File not Found, Uploader probably deleted it");
-				} catch(TaskCanceledException) {
-					errored("Download was cancelled");
-				} catch(Exception ex) {
-					if(!(ex is TaskCanceledException)) {
-						Plugin.Log.Warn("Download failed:");
-						Plugin.Log.Warn(ex);
-					}
-
-					firstEntry.status = DownloadHistoryEntry.DownloadStatus.Failed;
-					firstEntry.statusDetails = $"{(firstEntry.retries < 3 ? "(Will retry)" : "")}: Details in log, {ex.Message} ({ex.GetType().Name})";
-				}
-				firstEntry.downloadProgress = 1f;
-			});
+				firstEntry.status = DownloadHistoryEntry.DownloadStatus.Failed;
+				firstEntry.statusDetails = $"{(firstEntry.retries < 3 ? "(Will retry)" : "")}: Details in log, {ex.Message} ({ex.GetType().Name})";
+			}
+			firstEntry.downloadProgress = 1f;
 
 			if(firstEntry.status == DownloadHistoryEntry.DownloadStatus.Downloaded) {
 				// NESTING HELLLL

--- a/UI/SelectedSongView.cs
+++ b/UI/SelectedSongView.cs
@@ -46,6 +46,12 @@ namespace BetterSongSearch.UI {
 
 			if(selectedSong != null)
 				SetIsDownloaded(selectedSong.CheckIsDownloaded(), selectedSong.CheckIsDownloadable());
+
+			if(soloFreePlayFlowCoordinator == null)
+				soloFreePlayFlowCoordinator = FindObjectOfType<SoloFreePlayFlowCoordinator>();
+
+			if(multiplayerLevelSelectionFlowCoordinator == null)
+				multiplayerLevelSelectionFlowCoordinator = FindObjectOfType<MultiplayerLevelSelectionFlowCoordinator>();
 		}
 
 		static internal SongPreviewPlayer songPreviewPlayer { get; private set; } = null;
@@ -116,7 +122,9 @@ namespace BetterSongSearch.UI {
 					await Task.WhenAll(new[] {
 						BSSFlowCoordinator.assetLoader.LoadCoverAsync(song.detailsSong, songAssetLoadCanceller.Token).ContinueWith(
 							x => { coverImage.sprite = x.Result; },
-							TaskContinuationOptions.OnlyOnRanToCompletion
+							CancellationToken.None,
+							TaskContinuationOptions.OnlyOnRanToCompletion,
+							TaskScheduler.FromCurrentSynchronizationContext()
 						),
 
 						!PluginConfig.Instance.loadSongPreviews ? Task.FromResult(1) : BSSFlowCoordinator.assetLoader.LoadPreviewAsync(song.detailsSong, songAssetLoadCanceller.Token).ContinueWith(
@@ -171,8 +179,8 @@ namespace BetterSongSearch.UI {
 			songToPlayAfterLoading = null;
 		}
 
-		readonly SoloFreePlayFlowCoordinator soloFreePlayFlowCoordinator = FindObjectOfType<SoloFreePlayFlowCoordinator>();
-		readonly MultiplayerLevelSelectionFlowCoordinator multiplayerLevelSelectionFlowCoordinator = FindObjectOfType<MultiplayerLevelSelectionFlowCoordinator>();
+		SoloFreePlayFlowCoordinator soloFreePlayFlowCoordinator;
+		MultiplayerLevelSelectionFlowCoordinator multiplayerLevelSelectionFlowCoordinator;
 		static readonly ConstructorInfo LevelSelectionFlowCoordinator_State = AccessTools.FirstConstructor(typeof(LevelSelectionFlowCoordinator.State), x => x.GetParameters().Length == 4);
 
 		[UIAction("Play")] void _Play() => PlaySong();

--- a/UI/Views/SplitViews/UploadDetails.cs
+++ b/UI/Views/SplitViews/UploadDetails.cs
@@ -3,7 +3,6 @@ using BetterSongSearch.Util;
 using HMUI;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using TMPro;
 
 namespace BetterSongSearch.UI.SplitViews {
@@ -27,12 +26,12 @@ namespace BetterSongSearch.UI.SplitViews {
 
 			songDetailsLoading.gameObject.SetActive(true);
 
-			var desc = await Task.Run(async () => {
-				try {
-					return await BSSFlowCoordinator.assetLoader.GetSongDescription(selectedSong.detailsSong.key, BSSFlowCoordinator.closeCancelSource.Token);
-				} catch { }
-				return "Failed to load description";
-			});
+			string desc;
+			try {
+				desc = await BSSFlowCoordinator.assetLoader.GetSongDescription(selectedSong.detailsSong.key, BSSFlowCoordinator.closeCancelSource.Token);
+			} catch {
+				desc = "Failed to load description";
+			}
 
 			songDetailsLoading.gameObject.SetActive(false);
 			selectedSongDescription.text = desc;

--- a/Util/SongDownloader.cs
+++ b/Util/SongDownloader.cs
@@ -34,7 +34,9 @@ namespace BetterSongSearch.Util {
 				entry.status = DownloadHistoryEntry.DownloadStatus.Extracting;
 				progressCb(0);
 
-				await Task.Run(() => ExtractZip(s, folderName, t.Token, progressCb));
+				var sThread = SynchronizationContext.Current;
+
+				await Task.Run(() => ExtractZip(s, folderName, t.Token, (p) => sThread.Post(_ => progressCb(p), null)));
 			}
 		}
 
@@ -79,7 +81,7 @@ namespace BetterSongSearch.Util {
 							progress++;
 						}
 
-						UnityMainThreadTaskScheduler.Factory.StartNew(() => progressCb((float)++progress / steps));
+						progressCb((float)++progress / steps);
 					}
 				}
 
@@ -114,7 +116,7 @@ namespace BetterSongSearch.Util {
 						}
 					}
 
-					UnityMainThreadTaskScheduler.Factory.StartNew(() => progressCb((float)++progress / steps));
+					progressCb((float)++progress / steps);
 				}
 			} finally {
 				foreach(var item in files)

--- a/Util/SongDownloader.cs
+++ b/Util/SongDownloader.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using IPA.Utilities.Async;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -33,8 +34,7 @@ namespace BetterSongSearch.Util {
 				entry.status = DownloadHistoryEntry.DownloadStatus.Extracting;
 				progressCb(0);
 
-				// Not async'ing this as BeatmapDownload() is supposed to be called in a task
-				ExtractZip(s, folderName, t.Token, progressCb);
+				await Task.Run(() => ExtractZip(s, folderName, t.Token, progressCb));
 			}
 		}
 
@@ -79,7 +79,7 @@ namespace BetterSongSearch.Util {
 							progress++;
 						}
 
-						progressCb((float)++progress / steps);
+						UnityMainThreadTaskScheduler.Factory.StartNew(() => progressCb((float)++progress / steps));
 					}
 				}
 
@@ -114,7 +114,7 @@ namespace BetterSongSearch.Util {
 						}
 					}
 
-					progressCb((float)++progress / steps);
+					UnityMainThreadTaskScheduler.Factory.StartNew(() => progressCb((float)++progress / steps));
 				}
 			} finally {
 				foreach(var item in files)

--- a/Util/UnityWebrequestWrapper.cs
+++ b/Util/UnityWebrequestWrapper.cs
@@ -31,17 +31,22 @@ namespace BetterSongSearch.Util {
 						throw new TaskCanceledException();
 					}
 
-					if(timeouter.ElapsedMilliseconds > 50000 || (lastState == 0 && timeouter.ElapsedMilliseconds > 6000)) {
+					await Task.Delay(20);
+
+					if(lastState == www.downloadProgress) {
+						if(timeouter.ElapsedMilliseconds < (lastState == 0 ? 6000 : 10000))
+							continue;
+
 						www.Abort();
 						throw new TimeoutException();
 					}
-
-					await Task.Delay(20);
 
 					lastState = www.downloadProgress;
 
 					if(progressCb != null && lastState > 0)
 						progressCb(lastState);
+
+					timeouter.Restart();
 				}
 
 				return www.isDone && www.result == UnityWebRequest.Result.Success;


### PR DESCRIPTION
Fixes a few Unity things that were being called outside of the main thread. The slow work (web requests & unzipping) is still being done off of the main thread so this shouldn't cause additional stuttering.