### PR TITLE
Add WinHTTP fallback for Unity 6 network failures

### DIFF
--- a/BetterSongSearch.csproj
+++ b/BetterSongSearch.csproj
@@ -153,6 +153,9 @@
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.UI.dll</HintPath>
     </Reference>

--- a/Util/NativeHttpDownloader.cs
+++ b/Util/NativeHttpDownloader.cs
@@ -1,0 +1,136 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace BetterSongSearch.Util {
+	/// <summary>
+	/// Direct WinHTTP fallback for Unity 6 installations where UnityWebRequest
+	/// finishes with a transport error. It deliberately bypasses WinINET/WPAD
+	/// proxy discovery and only supports HTTPS GETs used by BeatSaver.
+	/// </summary>
+	static class NativeHttpDownloader {
+		// Beat Saber ships BSIPA's proxy as winhttp.dll beside the executable.
+		// Load the Windows implementation explicitly so the fallback does not
+		// resolve back into the same proxy that bootstraps IPA.
+		const uint LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
+		const uint WINHTTP_ACCESS_TYPE_NO_PROXY = 1;
+		const uint WINHTTP_FLAG_SECURE = 0x00800000;
+		const uint WINHTTP_QUERY_STATUS_CODE = 19;
+		const uint WINHTTP_QUERY_FLAG_NUMBER = 0x20000000;
+		static readonly IntPtr WinHttpModule = LoadSystemWinHttp();
+		static readonly WinHttpOpenDelegate WinHttpOpen = LoadFunction<WinHttpOpenDelegate>("WinHttpOpen");
+		static readonly WinHttpConnectDelegate WinHttpConnect = LoadFunction<WinHttpConnectDelegate>("WinHttpConnect");
+		static readonly WinHttpOpenRequestDelegate WinHttpOpenRequest = LoadFunction<WinHttpOpenRequestDelegate>("WinHttpOpenRequest");
+		static readonly WinHttpSendRequestDelegate WinHttpSendRequest = LoadFunction<WinHttpSendRequestDelegate>("WinHttpSendRequest");
+		static readonly WinHttpReceiveResponseDelegate WinHttpReceiveResponse = LoadFunction<WinHttpReceiveResponseDelegate>("WinHttpReceiveResponse");
+		static readonly WinHttpQueryHeadersDelegate WinHttpQueryHeaders = LoadFunction<WinHttpQueryHeadersDelegate>("WinHttpQueryHeaders");
+		static readonly WinHttpQueryDataAvailableDelegate WinHttpQueryDataAvailable = LoadFunction<WinHttpQueryDataAvailableDelegate>("WinHttpQueryDataAvailable");
+		static readonly WinHttpReadDataDelegate WinHttpReadData = LoadFunction<WinHttpReadDataDelegate>("WinHttpReadData");
+		static readonly WinHttpCloseHandleDelegate WinHttpCloseHandle = LoadFunction<WinHttpCloseHandleDelegate>("WinHttpCloseHandle");
+
+		public static byte[] Download(string url) {
+			var uri = new Uri(url);
+			if(!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+				throw new NotSupportedException("Only HTTPS downloads are supported by the native fallback");
+
+			IntPtr session = IntPtr.Zero;
+			IntPtr connection = IntPtr.Zero;
+			IntPtr request = IntPtr.Zero;
+			try {
+				session = WinHttpOpen(UnityWebrequestWrapper.UserAgent, WINHTTP_ACCESS_TYPE_NO_PROXY, null, null, 0);
+				EnsureHandle(session, "WinHttpOpen");
+				connection = WinHttpConnect(session, uri.Host, (ushort)uri.Port, 0);
+				EnsureHandle(connection, "WinHttpConnect");
+				request = WinHttpOpenRequest(connection, "GET", uri.PathAndQuery, null, null, IntPtr.Zero, WINHTTP_FLAG_SECURE);
+				EnsureHandle(request, "WinHttpOpenRequest");
+
+				if(!WinHttpSendRequest(request, null, 0, IntPtr.Zero, 0, 0, IntPtr.Zero))
+					ThrowLastError("WinHttpSendRequest");
+				if(!WinHttpReceiveResponse(request, IntPtr.Zero))
+					ThrowLastError("WinHttpReceiveResponse");
+
+				uint statusCode = 0;
+				uint statusCodeSize = sizeof(uint);
+				if(!WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, null, ref statusCode, ref statusCodeSize, IntPtr.Zero))
+					ThrowLastError("WinHttpQueryHeaders");
+				if(statusCode < 200 || statusCode >= 300)
+					throw new InvalidDataException($"HTTP {statusCode} returned for {url}");
+
+				using(var output = new MemoryStream()) {
+					while(true) {
+						if(!WinHttpQueryDataAvailable(request, out uint available))
+							ThrowLastError("WinHttpQueryDataAvailable");
+						if(available == 0)
+							break;
+						var buffer = new byte[(int)Math.Min(available, 1024u * 1024u)];
+						if(!WinHttpReadData(request, buffer, (uint)buffer.Length, out uint read))
+							ThrowLastError("WinHttpReadData");
+						if(read == 0)
+							break;
+						output.Write(buffer, 0, (int)read);
+					}
+					return output.ToArray();
+				}
+			} finally {
+				if(request != IntPtr.Zero) WinHttpCloseHandle(request);
+				if(connection != IntPtr.Zero) WinHttpCloseHandle(connection);
+				if(session != IntPtr.Zero) WinHttpCloseHandle(session);
+			}
+		}
+
+		static void EnsureHandle(IntPtr handle, string operation) {
+			if(handle == IntPtr.Zero)
+				ThrowLastError(operation);
+		}
+
+		static void ThrowLastError(string operation) {
+			var error = Marshal.GetLastWin32Error();
+			throw new Win32Exception(error, $"{operation} failed with Win32 error {error}");
+		}
+
+		static IntPtr LoadSystemWinHttp() {
+			var module = LoadLibraryEx("winhttp.dll", IntPtr.Zero, LOAD_LIBRARY_SEARCH_SYSTEM32);
+			if(module == IntPtr.Zero)
+				ThrowLastError("LoadLibraryEx(winhttp.dll)");
+			return module;
+		}
+
+		static T LoadFunction<T>(string name) where T : class {
+			var address = GetProcAddress(WinHttpModule, name);
+			if(address == IntPtr.Zero)
+				ThrowLastError($"GetProcAddress({name})");
+			return (T)(object)Marshal.GetDelegateForFunctionPointer(address, typeof(T));
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
+		delegate IntPtr WinHttpOpenDelegate(string userAgent, uint accessType, string proxyName, string proxyBypass, uint flags);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
+		delegate IntPtr WinHttpConnectDelegate(IntPtr session, string serverName, ushort serverPort, uint reserved);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
+		delegate IntPtr WinHttpOpenRequestDelegate(IntPtr connect, string verb, string objectName, string version, string referrer, IntPtr acceptTypes, uint flags);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpSendRequestDelegate(IntPtr request, string headers, uint headersLength, IntPtr optional, uint optionalLength, uint totalLength, IntPtr context);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpReceiveResponseDelegate(IntPtr request, IntPtr reserved);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, CharSet = CharSet.Unicode, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpQueryHeadersDelegate(IntPtr request, uint infoLevel, string name, ref uint buffer, ref uint bufferLength, IntPtr index);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpQueryDataAvailableDelegate(IntPtr request, out uint available);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpReadDataDelegate(IntPtr request, byte[] buffer, uint bytesToRead, out uint bytesRead);
+		[UnmanagedFunctionPointer(CallingConvention.Winapi, SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		delegate bool WinHttpCloseHandleDelegate(IntPtr handle);
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+		static extern IntPtr LoadLibraryEx(string fileName, IntPtr file, uint flags);
+		[DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+		static extern IntPtr GetProcAddress(IntPtr module, string procedureName);
+	}
+}

--- a/Util/UnityWebrequestWrapper.cs
+++ b/Util/UnityWebrequestWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.IO;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -49,7 +51,10 @@ namespace BetterSongSearch.Util {
 					timeouter.Restart();
 				}
 
-				return www.isDone && www.result == UnityWebRequest.Result.Success;
+				var successful = www.isDone && www.result == UnityWebRequest.Result.Success;
+				if(!successful)
+					Plugin.Log.Warn($"UnityWebRequest failed: result={www.result}, status={www.responseCode}, error={www.error}, url={url}");
+				return successful;
 			} finally {
 				if(www != null && uwr == null)
 					www.Dispose();
@@ -57,21 +62,38 @@ namespace BetterSongSearch.Util {
 		}
 
 		public static async Task<byte[]> DownloadBytes(string url, CancellationToken token = default, Action<float> progressCb = null) {
-			using(var dhb = new DownloadHandlerBuffer())
-				return await Download(url, dhb, token, progressCb) ? dhb.data : null;
+			using(var dhb = new DownloadHandlerBuffer()) {
+				if(await Download(url, dhb, token, progressCb))
+					return dhb.data;
+			}
+
+			token.ThrowIfCancellationRequested();
+			Plugin.Log.Warn($"Retrying through direct WinHTTP: {url}");
+			var bytes = await Task.Run(() => NativeHttpDownloader.Download(url), token);
+			Plugin.Log.Info($"Direct WinHTTP downloaded {bytes.Length} bytes from {url}");
+			return bytes;
 		}
 
 		public static async Task<string> DownloadText(string url, CancellationToken token = default, Action<float> progressCb = null) {
-			using(var dhb = new DownloadHandlerBuffer())
-				return await Download(url, dhb, token, progressCb) ? dhb.text : null;
+			return Encoding.UTF8.GetString(await DownloadBytes(url, token, progressCb));
 		}
 
 		public static async Task<Sprite> DownloadSprite(string url, CancellationToken token = default, Action<float> progressCb = null) {
 			using(var dhb = new DownloadHandlerTexture()) {
-				if(!await Download(url, dhb, token, progressCb))
-					return null;
-
-				var t = dhb.texture;
+				Texture2D t;
+				if(await Download(url, dhb, token, progressCb)) {
+					t = dhb.texture;
+				} else {
+					token.ThrowIfCancellationRequested();
+					Plugin.Log.Warn($"Retrying cover through direct WinHTTP: {url}");
+					var bytes = await Task.Run(() => NativeHttpDownloader.Download(url), token);
+					t = new Texture2D(2, 2);
+					if(!t.LoadImage(bytes, true)) {
+						UnityEngine.Object.Destroy(t);
+						return null;
+					}
+					Plugin.Log.Info($"Direct WinHTTP loaded cover ({bytes.Length} bytes) from {url}");
+				}
 
 				t.wrapMode = TextureWrapMode.Clamp;
 				return Sprite.Create(t, new Rect(0, 0, t.width, t.height), Vector3.zero, 100);
@@ -80,10 +102,31 @@ namespace BetterSongSearch.Util {
 
 		public static async Task<AudioClip> DownloadAudio(string url, CancellationToken token = default, AudioType type = AudioType.UNKNOWN, Action<float> progressCb = null) {
 			using(var www = UnityWebRequestMultimedia.GetAudioClip(url, type)) {
-				if(!await Download(url, null, token, progressCb, www))
-					return null;
+				if(await Download(url, null, token, progressCb, www))
+					return DownloadHandlerAudioClip.GetContent(www);
+			}
 
-				return DownloadHandlerAudioClip.GetContent(www);
+			token.ThrowIfCancellationRequested();
+			Plugin.Log.Warn($"Retrying preview through direct WinHTTP: {url}");
+			var bytes = await Task.Run(() => NativeHttpDownloader.Download(url), token);
+			var tempPath = Path.Combine(Path.GetTempPath(), $"BetterSongSearch-{Guid.NewGuid():N}.mp3");
+			try {
+				await Task.Run(() => File.WriteAllBytes(tempPath, bytes), token);
+				var localUrl = new Uri(tempPath).AbsoluteUri;
+				using(var localRequest = UnityWebRequestMultimedia.GetAudioClip(localUrl, type)) {
+					if(!await Download(localUrl, null, token, progressCb, localRequest))
+						return null;
+
+					var clip = DownloadHandlerAudioClip.GetContent(localRequest);
+					Plugin.Log.Info($"Direct WinHTTP loaded preview ({bytes.Length} bytes) from {url}");
+					return clip;
+				}
+			} finally {
+				try {
+					File.Delete(tempPath);
+				} catch(Exception ex) {
+					Plugin.Log.Debug($"Could not remove temporary preview {tempPath}: {ex.Message}");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a Windows system WinHTTP fallback for BeatSaver requests when UnityWebRequest fails at the transport layer.

The fallback covers:

- metadata and byte downloads
- cover images
- song ZIPs
- preview audio (downloaded natively, then decoded by Unity from a temporary local file)

It also logs the UnityWebRequest result, response status, error, and URL before falling back.

## Why

On Beat Saber 1.42.1 / Unity 6000.0.40f1, BeatSaver requests could consistently finish with:

```
result=ConnectionError, status=0, error=Cannot connect to destination host
```

The same endpoints were reachable outside the game process. A bare `DllImport("winhttp.dll")` was not sufficient because BSIPA places its proxy `winhttp.dll` beside the game executable. The fallback therefore loads the Windows implementation using `LoadLibraryEx(..., LOAD_LIBRARY_SEARCH_SYSTEM32)` and resolves the required exports directly.

UnityWebRequest remains the primary path; WinHTTP is only used after a request fails.

## Verification

- `dotnet build -c Release` against a Beat Saber 1.42.1 installation
- In-process WinHTTP request to `https://api.beatsaver.com/maps/id/225eb`
- In-game cover loading
- In-game preview playback
- In-game map ZIP download and extraction
- Verified fallback against both `cdn.beatsaver.com` and `r2cdn.beatsaver.com`

All of the in-game behaviors above were manually confirmed on Windows with Unity 6000.0.40f1.